### PR TITLE
adds pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Describe your changes
+
+## User story
+
+## Checklist before requesting a review
+- [ ] I have ensured rspec suite is passing in its entirety 


### PR DESCRIPTION
pull request template should auto-populate for all PRs moving forward, as long as you are pointing the changes to Derek's branch of little-shop-7 as opposed to turing's main branch. 